### PR TITLE
reworked _refund_cleanup_lines and test refund from claim

### DIFF
--- a/crm_claim_rma/models/account_invoice.py
+++ b/crm_claim_rma/models/account_invoice.py
@@ -4,7 +4,9 @@
 # © 2009-2013 Akretion,
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp import _, api, exceptions, fields, models
+import itertools
+
+from odoo import _, api, exceptions, fields, models
 
 
 class AccountInvoice(models.Model):
@@ -13,48 +15,49 @@ class AccountInvoice(models.Model):
 
     claim_id = fields.Many2one('crm.claim', string='Claim')
 
+    @api.model
     def _refund_cleanup_lines(self, lines):
-        """ Override when from claim to update the quantity and link to the
-        claim line.
+        """ Override when from claim to update the quantity, link to the
+        claim line and return empty list for tax_line_ids.
         """
+        claim_lines_context = self.env.context.get('claim_line_ids')
 
-        # check if is an invoice_line and we are from a claim
-        if not (self.env.context.get('claim_line_ids') and lines and
-                lines[0]._name == 'account.invoice.line'):
+        if not (lines and claim_lines_context):
             return super(AccountInvoice, self)._refund_cleanup_lines(lines)
 
-        # start by browsing all the lines so that Odoo will correctly prefetch
-        line_ids = [l[1] for l in self.env.context['claim_line_ids']]
-        claim_lines = self.env['claim.line'].browse(line_ids)
+        # We don't want tax_line_ids from origin invoice as new ones
+        # will be calculated for correct number of lines
 
-        new_lines = []
-        for claim_line in claim_lines:
-            if not claim_line.refund_line_id:
-                # For each lines replace quantity and add claim_line_id
-                inv_line = claim_line.invoice_line_id
-                clean_line = {}
-                for field_name, field in inv_line._all_columns.iteritems():
-                    column_type = field.column._type
-                    if column_type == 'many2one':
-                        clean_line[field_name] = inv_line[field_name].id
-                    elif column_type not in ('many2many', 'one2many'):
-                        clean_line[field_name] = inv_line[field_name]
-                    elif field_name == 'invoice_line_tax_id':
+        if lines[0]._name == 'account.invoice.tax':
+            return []
 
-                        tax_ids = inv_line[field_name].ids
-                        clean_line[field_name] = [(6, 0, tax_ids)]
-                clean_line['quantity'] = claim_line.product_returned_quantity
-                clean_line['claim_line_id'] = [claim_line.id]
+        claim_lines = self.env['claim.line'].browse([l[1] for l in claim_lines_context])
+        claim_lines_wo_refund = claim_lines.filtered(lambda s: not s.refund_line_id).sorted('invoice_line_id')
 
-                new_lines.append(clean_line)
-        if not new_lines:
-            # TODO use custom states to show button of this wizard or
-            # not instead of raise an error
+        if not claim_lines_wo_refund:
 
             raise exceptions.UserError(
-                _('A refund has already been created for this claim !')
+                _('A refund has already been created for all lines on this claim !')
             )
-        return [(0, 0, l) for l in new_lines]
+
+        # _refund_cleanup_lines keep original sequence so instead of C/P Odoo code
+        #  we can sort record set and update create values.
+
+        invoice_lines = claim_lines_wo_refund.mapped('invoice_line_id').sorted()
+
+        # data from res in format (0, 0, {field:value})
+        refund_invoice_lines_data = super(AccountInvoice, self)._refund_cleanup_lines(invoice_lines)
+
+        for claim_line, invoice_create_values in itertools.izip(
+                claim_lines_wo_refund,
+                refund_invoice_lines_data):
+
+            create_values = invoice_create_values[2]
+            create_values.update(
+                quantity=claim_line.product_returned_quantity,
+                claim_line_id=claim_line.id,
+            )
+        return refund_invoice_lines_data
 
     @api.model
     def _prepare_refund(self, *args, **kwargs):

--- a/crm_claim_rma/tests/test_claim.py
+++ b/crm_claim_rma/tests/test_claim.py
@@ -30,3 +30,39 @@ class TestClaim(TransactionCase):
         self.assertEqual(supplier_type, claim.claim_type)
         self.assertIsNotNone(claim.code)
         self.assertTrue(claim.code.startswith('RMA-V/'))
+
+    def test_refund_from_claim(self):
+        invoice_ids = self.env.ref('sale.sale_order_4').action_invoice_create()
+        invoice = self.env['account.invoice'].browse(invoice_ids[0])
+        invoice.invoice_validate()
+        invoice_lines = invoice.mapped('invoice_line_ids')
+        default_tax = self.env['res.company']._company_default_get('account.tax')
+        invoice_lines.write(
+            {'invoice_line_tax_ids': [(4, default_tax.id, 0)]}
+        )
+        claim = self.env['crm.claim'].create({
+            'name': 'Test claim',
+            'invoice_id': invoice.id
+        })
+        claim._onchange_invoice()
+        claim.claim_line_ids[0].unlink()
+        refund_wizard = self.env['account.invoice.refund'].with_context({
+            'invoice_ids': [claim.invoice_id.id],
+            'claim_line_ids': [(4, line.id, 0) for line in claim.claim_line_ids],
+            'description': claim.name,
+            'claim_id': claim.id,
+        }).create({})
+        refund = refund_wizard.compute_refund()
+        refund_invoice = self.env['account.invoice'].search(refund['domain'])
+
+        self.assertTrue(refund_invoice)
+        self.assertEqual(len(refund_invoice.invoice_line_ids), len(claim.claim_line_ids))
+        self.assertEqual(
+            refund_invoice.invoice_line_ids.mapped('invoice_line_tax_ids'),
+            claim.claim_line_ids.mapped('invoice_line_id.invoice_line_tax_ids'),
+        )
+        self.assertEqual(
+            refund_invoice.invoice_line_ids.mapped('quantity'),
+            claim.claim_line_ids.mapped('product_returned_quantity'),
+        )
+        self.assertTrue(refund_invoice.tax_line_ids[0].tax_id.refund_account_id)

--- a/crm_claim_rma/views/claim_line.xml
+++ b/crm_claim_rma/views/claim_line.xml
@@ -115,7 +115,7 @@
                         <field name="claim_origin" colspan="6"/>
                         <field name="claim_diagnosis" colspan="6"/>
                         <field name="priority" colspan="6"/>
-                        <field name="product_returned_quantity" invisible="1"/>
+                        <field name="product_returned_quantity"/>
                         <field name="unit_sale_price"/>
                         <field name="return_value"/>
                     </group>


### PR DESCRIPTION
https://hive.versada.eu/work_packages/11525

- _refund_cleanup_lines now uses index to add claim values, there is no need
to C/P Odoo's code to acheive this
- _refund_cleanup_lines now returns empty list for account.invoice.tax calls to it,
this is needed because origin tax lines are sum-up of all taxes and in case of claim
not all invoice lines are refunded. This also fixes wrong field name, see https://github.com/OCA/rma/issues/147

- [Original Odoo method](https://github.com/odoo/odoo/blob/91807404e7d5c314ea30926b44bd16e878417ec1/addons/account/models/account_invoice.py#L985)
- [Used here](https://github.com/odoo/odoo/blob/91807404e7d5c314ea30926b44bd16e878417ec1/addons/account/models/account_invoice.py#L1039)
- [OCA artwork](https://github.com/OCA/rma/blob/f0656eb39c55081eff52ad502a0a1deb648b0822/crm_claim_rma/models/account_invoice.py#L16)
